### PR TITLE
Fix creating custom properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Custom
 pytest_token*
 .vscode
+playground/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="dictionizr",
-    version="1.0.3",
+    version="1.0.4",
     author="Joseph Riddle",
     author_email="joeriddles10@gmail.com",
     description="A small package to convert custom python objects to dictionaries and back again",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .dictionizr_test import Data

--- a/tests/dictionizr_test.py
+++ b/tests/dictionizr_test.py
@@ -8,17 +8,21 @@ from .utils import eq
 
 class Data():
     name: str
+    sub_name: Optional[Data] = None
     data: Optional[Data] = None
     optional: Optional[str] = None
     datas: Optional[list[Data]] = None
     def __init__(self,
         name: str,
         sub_name: Optional[str] = None,
+        data: Optional[Data] = None,
         datas: Optional[list[Data]] = None,
     ):
         self.name = name
         if sub_name is not None:
-            self.data = Data(sub_name)
+            self.sub_name = Data(sub_name)
+        if data is not None:
+            self.data = data
         if datas is not None:
             self.datas = datas
 
@@ -44,7 +48,7 @@ def test__dictionize__no_functions():
 
 
 def test__dictionize__sub_objects():
-    data = Data('Joe', 'John')
+    data = Data('Joe', data=Data('John'))
     actual = dictionize(data)
     expected = {
         'name': 'Joe',
@@ -66,7 +70,7 @@ def test__undictionize__sub_object():
         'data': { 'name': 'John'}
     }
     actual = undictionize(data, Data)
-    expected = Data('Joe', 'John')
+    expected = Data('Joe', data=Data('John'))
     assert expected == actual
 
 
@@ -118,13 +122,12 @@ def test__undictionize__object_method_works():
     assert expected == actual
 
 
-# TODO: Figure out how to undictionize subobjects to correct class type easily
-# def test__undictionize__sub_object_method_works():
-#     data = {
-#         'name': 'Joe',
-#         'data': { 'name': 'John'}
-#     }
-#     actual_obj = undictionize(data, Data)
-#     actual = actual_obj.data.hello()
-#     expected = 'hello John'
-#     assert expected == actual
+def test__undictionize__sub_object_method_works():
+    data = {
+        'name': 'Joe',
+        'data': { 'name': 'John'}
+    }
+    actual_obj = undictionize(data, Data, module_path='tests.dictionizr_test')
+    actual = actual_obj.data.hello()
+    expected = 'hello John'
+    assert expected == actual


### PR DESCRIPTION
Currently, this test will fail:
```
class Data():
    name: str
    data: Optional[Data] = None
    optional: Optional[str] = None
    datas: Optional[list[Data]] = None
    def __init__(self,
        name: str,
        sub_name: Optional[str] = None,
        datas: Optional[list[Data]] = None,
    ):
        self.name = name
        if sub_name is not None:
            self.data = Data(sub_name)
        if datas is not None:
            self.datas = datas

    def __eq__(self, o: Data) -> bool:
        return eq(self, o) # custom equality function for easy testing

    def hello(self) -> str:
        return f'hello {self.name}'


def test__undictionize__sub_object_method_works():
     data = {
         'name': 'Joe',
         'data': { 'name': 'John'}
     }
     actual_obj = undictionize(data, Data)
     actual = actual_obj.data.hello()
     expected = 'hello John'
     assert expected == actual
```

## Goal is to make this test pass